### PR TITLE
adding asio header files to the include directories list because make…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc
                     ${CMAKE_CURRENT_SOURCE_DIR}/lib_joystick
                     ${CMAKE_CURRENT_SOURCE_DIR}/lib_utils
                     ${CMAKE_CURRENT_SOURCE_DIR}/lib_openvslam/openvslam/src
+                    ${CMAKE_CURRENT_SOURCE_DIR}/lib_openvslam/external_dependencies/socket.io-client-cpp/lib/asio/asio/include
                    )
 
 file( GLOB LIB_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)


### PR DESCRIPTION
… gives an error of 'asio.hpp' not found (from Joystick target), unless the include dirs is updated